### PR TITLE
feat: chuck/stream downloads instead of reading everything into RAM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = "0.3"
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Used Uphold.AI Extension for Code:

In this updated code, the `reqwest::get()` method is replaced with `client.get().send()`, which returns a `reqwest::Response`. Then, we iterate over the chunks using `response.chunk().await?` and write each chunk to the file using `file.write_all(&chunk)?`.

Note that we also added the `futures::StreamExt` trait for the ability to use `response.chunk().await?`. You may need to add the `futures` crate to your `Cargo.toml` dependencies if you haven't already.

Make sure to adjust the code according to your specific needs and error handling requirements.
