### PR TITLE
feat: add graceful signal handling for downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +478,7 @@ name = "ia-get"
 version = "0.1.2"
 dependencies = [
  "clap",
+ "ctrlc",
  "futures",
  "indicatif",
  "md5",
@@ -704,6 +715,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde-xml-rs = "0.8.0"
 thiserror = "1.0"
 url = "2.4.1"
 clap = { version = "4.0", features = ["derive"] }
+ctrlc = "3.4"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.


### PR DESCRIPTION
- Implement Ctrl+C signal handler with Arc<AtomicBool> for thread-safe state
- Add signal interruption checks in download loops and MD5 calculation
- Preserve download progress when interrupted, allowing seamless resume
- Provide clear user feedback on interruption with resume instructions
- Ensure progress bars are properly cleaned up on signal interruption

This enables users to gracefully cancel long-running downloads while maintaining the ability to resume from where they left off by running the same command again.
