### PR TITLE
refactor: improve URL validation and error messages

### DIFF
--- a/src/archive_metadata.rs
+++ b/src/archive_metadata.rs
@@ -57,7 +57,7 @@ pub fn parse_xml_files(xml_content: &str) -> Result<XmlFiles> {
             xml_content
         };
         
-        IaGetError::XmlParse(format!(
+        IaGetError::XmlParsing(format!(
             "Failed to parse XML metadata: {}. Content preview: {}{}",
             e,
             preview,

--- a/src/archive_metadata.rs
+++ b/src/archive_metadata.rs
@@ -58,7 +58,7 @@ pub fn parse_xml_files(xml_content: &str) -> Result<XmlFiles> {
         };
         
         IaGetError::XmlParsing(format!(
-            "Failed to parse XML metadata: {}. Content preview: {}{}",
+            "Failed to parse _files.xml metadata: {}. Content preview: {}{}",
             e,
             preview,
             if xml_content.len() > XML_DEBUG_TRUNCATE_LEN { "..." } else { "" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,6 @@ pub enum IaGetError {
     /// XML parsing errors
     #[error("Failed to parse XML: {0}")]
     XmlParsing(String),
-
-    /// XML parsing error
-    #[error("XML parsing error: {0}")]
-    XmlParse(String),
 }
 
 impl From<reqwest::Error> for IaGetError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum IaGetError {
     FileSystem(String),
 
     /// URL format or parsing errors
-    #[error("Invalid URL: {0}")]
+    #[error("Invalid archive.org URL: {0}. Expected format: https://archive.org/details/<identifier>[/]")]
     UrlFormat(String),
 
     /// MD5 hash verification failures

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,9 +119,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     
     // Validate URL format using consolidated function
     if let Err(e) = validate_archive_url(&cli.url) {
-        spinner.finish_with_message(format!("❌ Invalid archive.org URL format: {}", cli.url));
-        println!("├╼ Archive.org URL is not in the expected format");
-        println!("╰╼ Expected format: https://archive.org/details/<identifier>[/]");
+        spinner.finish_with_message(format!("❌ {}", e));
         return Err(e.into());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ fn get_xml_url(original_url: &str) -> String {
     let trimmed_url = original_url.trim_end_matches('/');
 
     // The identifier is the last segment of the trimmed URL
+    // This expect is considered safe because get_xml_url is only called after
+    // validate_archive_url has confirmed the URL structure.
     let identifier = trimmed_url.split('/').last()
         .expect("Validated URL should have a valid identifier segment after validation");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,13 +33,15 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// ```
 pub fn validate_archive_url(url: &str) -> Result<()> {
     if URL_REGEX.is_match(url) {
-        Ok(())
-    } else {
-        Err(IaGetError::UrlFormat(format!(
-            "URL '{}' does not match expected format. Expected: https://archive.org/details/<identifier>[/]", 
-            url
-        )))
+        // Further check: ensure there's an identifier after "details/"
+        // and that the identifier is not empty.
+        if let Some(path_segment) = url.split("/details/").nth(1) {
+            if !path_segment.trim_end_matches('/').is_empty() {
+                return Ok(());
+            }
+        }
     }
+    Err(IaGetError::UrlFormat(url.to_string()))
 }
 
 /// Create a progress bar with consistent styling


### PR DESCRIPTION
Enhances the validation of archive.org URLs and refines related error messages for clarity and accuracy:

- Improves URL validation by checking for the presence of a non-empty identifier after "/details/".
- Updates the error message for invalid URLs to provide a more informative message about the expected format.
- Renames the `XmlParse` error variant to `XmlParsing` for consistency and clarity.
- Removes redundant XML parsing error variant.