### PR TITLE
ui: replace emoji with coloured unicode symbols/glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +488,7 @@ name = "ia-get"
 version = "0.1.2"
 dependencies = [
  "clap",
+ "colored",
  "ctrlc",
  "futures",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0"
 url = "2.4.1"
 clap = { version = "4.0", features = ["derive"] }
 ctrlc = "3.4"
+colored = "2.1.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 use crate::constants::URL_PATTERN;
 use crate::{Result, IaGetError};
+use colored::*; // Add this line
 
 /// Spinner tick interval in milliseconds
 pub const SPINNER_TICK_INTERVAL: u64 = 100;
@@ -57,11 +58,18 @@ pub fn validate_archive_url(url: &str) -> Result<()> {
 pub fn create_progress_bar(total: u64, action: &str, color: Option<&str>, with_eta: bool) -> ProgressBar {
     let pb = ProgressBar::new(total);
     let color_str = color.unwrap_or("green/green");
+
+    let styled_action = if action.contains("├╼") || action.contains("╰╼") {
+        action.replace("├╼", &"├╼".cyan().dimmed().to_string())
+              .replace("╰╼", &"╰╼".cyan().dimmed().to_string())
+    } else {
+        action.to_string()
+    };
     
     let template = if with_eta {
-        format!("{action}{{elapsed_precise}}     {{bar:40.{color_str}}} {{bytes}}/{{total_bytes}} (ETA: {{eta}})")
+        format!("{}{{elapsed_precise}} {{bar:40.{}}} {{bytes}}/{{total_bytes}} (ETA: {{eta}})", styled_action, color_str)
     } else {
-        format!("{action}{{elapsed_precise}}     {{bar:40.{color_str}}} {{bytes}}/{{total_bytes}}")
+        format!("{}{{elapsed_precise}} {{bar:40.{}}} {{bytes}}/{{total_bytes}}", styled_action, color_str)
     };
     
     pb.set_style(
@@ -86,7 +94,7 @@ pub fn create_spinner(message: &str) -> ProgressBar {
     spinner.set_style(
         ProgressStyle::default_spinner()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-            .template(&format!("{{spinner}} {message}"))
+            .template(&format!("{} {}", "{spinner}".yellow().bold(), message))
             .expect("Failed to set spinner style")
     );
     spinner.enable_steady_tick(std::time::Duration::from_millis(SPINNER_TICK_INTERVAL));


### PR DESCRIPTION
This commit enhances the user interface by adding coloured glyphs/symbols instead of emoji.

- Added the coloured crate as a dependency.
- Modified downloader.rs to incorporate coloured output for download status, MD5 hashing, and error messages.
- Updated main.rs to use colours in spinner messages and validation feedback.
- Modified utils.rs to format progress bar messages with colours.
- Reduced the LARGE_FILE_THRESHOLD in downloader.rs from 16MB to 2MB, to trigger hashing progress bar more frequently.
