### PR TITLE
feat: add --list/-l parameter to show files that would be downloaded

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use colored::*;
 use ia_get::archive_metadata::{parse_xml_files, XmlFiles};
 use ia_get::constants::USER_AGENT;
 use ia_get::downloader;
-use ia_get::utils::{create_spinner, sanitize_filename, validate_archive_url};
+use ia_get::utils::{create_spinner, sanitize_filename, validate_archive_url, format_size};
 use ia_get::Result;
 use indicatif::ProgressStyle;
 use reqwest::Client;
@@ -124,7 +124,7 @@ fn list_files(files: &XmlFiles, spinner: &indicatif::ProgressBar) {
     );
     spinner.finish();
     for file in &files.files {
-        println!("{} {}", file.size.map(|n| n.to_string()).unwrap_or("???".to_string()), file.name.bold());
+        println!("{} {}", file.size.map(|n| format_size(n)).unwrap_or("???".to_string()), file.name.bold());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // If requested, list parsed filenames and exit
     if cli.list {
+        spinner.set_style(
+            ProgressStyle::default_spinner()
+                .template(&format!(
+                    "{} Archive has {} files",
+                    "✔".green().bold(),
+                    files.files.len().to_string().bold()
+                ))
+            .expect("Failed to set completion style"),
+        );
         spinner.finish();
         for file in &files.files {
             println!("{}", file.name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,23 @@ async fn fetch_xml_metadata(
     Ok((files, base_url))
 }
 
+/// Lists parsed filenames from XML metadata when --list/-l is used
+fn list_files(files: &XmlFiles, spinner: &indicatif::ProgressBar) {
+    spinner.set_style(
+        ProgressStyle::default_spinner()
+            .template(&format!(
+                "{} Archive has {} files",
+                "✔".green().bold(),
+                files.files.len().to_string().bold()
+            ))
+        .expect("Failed to set completion style"),
+    );
+    spinner.finish();
+    for file in &files.files {
+        println!("{}", file.name);
+    }
+}
+
 /// Command-line interface for ia-get
 #[derive(Parser)]
 #[command(name = "ia-get")]
@@ -168,19 +185,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // If requested, list parsed filenames and exit
     if cli.list {
-        spinner.set_style(
-            ProgressStyle::default_spinner()
-                .template(&format!(
-                    "{} Archive has {} files",
-                    "✔".green().bold(),
-                    files.files.len().to_string().bold()
-                ))
-            .expect("Failed to set completion style"),
-        );
-        spinner.finish();
-        for file in &files.files {
-            println!("{}", file.name);
-        }
+        list_files(&files, &spinner);
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ async fn fetch_xml_metadata(
 struct Cli {
     /// URL to an archive.org details page
     url: String,
+    /// List files parsed from archive metadata XML and exit
+    #[arg(long)]
+    list: bool,
 }
 
 /// Main application entry point
@@ -162,6 +165,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Fetch and parse XML metadata in one operation
     let (files, base_url) = fetch_xml_metadata(&cli.url, &client, &spinner).await?;
+
+    // If requested, list parsed filenames and exit
+    if cli.list {
+        spinner.finish();
+        for file in &files.files {
+            println!("{}", file.name);
+        }
+        return Ok(());
+    }
 
     // Successfully finished initialization
     spinner.set_style(

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn list_files(files: &XmlFiles, spinner: &indicatif::ProgressBar) {
     );
     spinner.finish();
     for file in &files.files {
-        println!("{}", file.name);
+        println!("{} {}", file.size.map(|n| n.to_string()).unwrap_or("???".to_string()), file.name.bold());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ struct Cli {
     /// URL to an archive.org details page
     url: String,
     /// List files parsed from archive metadata XML and exit
-    #[arg(long)]
+    #[arg(short = 'l', long = "list")]
     list: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn list_files(files: &XmlFiles, spinner: &indicatif::ProgressBar) {
     );
     spinner.finish();
     for file in &files.files {
-        println!("{} {}", file.size.map(|n| format_size(n)).unwrap_or("???".to_string()), file.name.bold());
+        println!("{:>9} {}", file.size.map(|n| format_size(n)).unwrap_or("???".to_string()), file.name.bold());
     }
 }
 


### PR DESCRIPTION
Hey :)

Would you be open to adding `--list` param? It gives the user an idea how many files (and their sizes) would be downloaded.
 
<img width="866" height="310" alt="image" src="https://github.com/user-attachments/assets/d0c62eb5-548a-4887-9e48-9b13aa37d820" />
