### PR TITLE
ci: add Dependabot Nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- enable Dependabot version updates for Nix flakes
- let Dependabot maintain `flake.lock` inputs on a weekly schedule
- remove the old `DeterminateSystems/update-flake-lock` automation to avoid duplicate lockfile PRs

## Context
GitHub now supports Nix flakes in Dependabot version updates:
https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/

## Validation
- `git diff --check`
- verified every active flake repo has a `nix` Dependabot entry
- verified no `DeterminateSystems/update-flake-lock`, `update_flake_lock`, or `update-flake-lock` references remain
