### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "ia-get"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["cli", "archive", "internet-archive", "download"]
 authors = ["Martin Wimpress <code@wimpress.io>"]
 repository = "https://github.com/wimpysworld/ia-get"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary
- Bumps `ia-get` crate/package version from `0.1.3` to `0.1.4`.
- Keeps `Cargo.toml` and `Cargo.lock` aligned before tagging the next release.

## Release prep
This prepares the repository for a `0.1.4` tag so release artefacts and Rust package metadata report the same version.

## Test Plan
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all --check`
- `cargo test`
- `cargo audit --deny warnings`
- `git diff --check`
