### PR TITLE
chore: remove flake lock updater

### DIFF
--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -28,25 +28,3 @@ jobs:
         with:
           branch: tailor-alter
           title: "chore: alter tailor swatches"
-
-  update-flake-lock:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for flake.lock
-        id: check
-        run: test -f flake.lock && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
-
-      - name: Install Nix
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: Update flake.lock
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/update-flake-lock@v28
-        with:
-          pr-title: "chore: update flake.lock"


### PR DESCRIPTION
## Summary
- Remove the `update-flake-lock` job from the Tailor workflow
- Drop the DeterminateSystems update-flake-lock action from scheduled automation
- Leave the Tailor swatch alteration job unchanged

## Test Plan
- `git diff --check`
- `yq -e '.jobs | keys' .github/workflows/tailor.yml`
- `rg -n 'DeterminateSystems/update-flake-lock|update-flake-lock|determinate-nix-action|chore: update flake\.lock' .github/workflows .github/dependabot.yml` confirmed no updater refs remain

Requested by Martin in https://github.com/wimpysworld/ia-get/pull/125#issuecomment-4621577757
