### PR TITLE
ci: remove detsys flake lock updater

### DIFF
--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -28,25 +28,3 @@ jobs:
         with:
           branch: tailor-alter
           title: "chore: alter tailor swatches"
-
-  update-flake-lock:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for flake.lock
-        id: check
-        run: test -f flake.lock && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
-
-      - name: Install Nix
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: Update flake.lock
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/update-flake-lock@v28
-        with:
-          pr-title: "chore: update flake.lock"


### PR DESCRIPTION
## Summary
- Removes the Determinate Systems update-flake-lock job from Tailor.
- Leaves the normal Tailor alteration workflow in place.
- Requested by Martin in wimpysworld/ia-get#125.

## Validation
- YAML parses.
- `git diff --check` passes.
- Search confirms no detsys flake-lock updater refs remain under `.github`.
